### PR TITLE
Allow bypassing HTML content unescaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1
+* Allow bypassing HTML content unescaping
+
 ## 4.0.0
 * Breaking change, this package now needs a Flutter version >= 3
 * Update dependencies

--- a/lib/src/html_stylist.dart
+++ b/lib/src/html_stylist.dart
@@ -56,11 +56,12 @@ class HTML {
   /// );
   /// ```
 
-  static TextSpan toTextSpan(BuildContext context, String htmlContent,
-      {Function(dynamic)? linksCallback,
-      Map<String, TextStyle>? overrideStyle,
-      TextStyle? defaultTextStyle,
-      bool unescapeContent = true}) {
+  static TextSpan toTextSpan(BuildContext context, String htmlContent, {
+    Function(dynamic)? linksCallback,
+    Map<String, TextStyle>? overrideStyle,
+    TextStyle? defaultTextStyle,
+    bool unescapeContent = true,
+  }) {
     // Validating empty content
     if (htmlContent.isEmpty) {
       return const TextSpan();
@@ -126,11 +127,12 @@ class HTML {
   /// );
   /// ```
 
-  static RichText toRichText(BuildContext context, String htmlContent,
-      {Function(dynamic)? linksCallback,
-      Map<String, TextStyle>? overrideStyle,
-      TextStyle? defaultTextStyle,
-      bool unescapeContent = true}) {
+  static RichText toRichText(BuildContext context, String htmlContent, {
+    Function(dynamic)? linksCallback,
+    Map<String, TextStyle>? overrideStyle,
+    TextStyle? defaultTextStyle,
+    bool unescapeContent = true,
+  }) {
     return RichText(
       text: toTextSpan(
         context,

--- a/lib/src/html_stylist.dart
+++ b/lib/src/html_stylist.dart
@@ -55,6 +55,16 @@ class HTML {
   ///   },
   /// );
   /// ```
+  ///
+  /// HTML content is unescaped by default before parsing to render escape
+  /// entities contained in the input. For example:
+  /// ```
+  /// <b>2 &times; 4 &#61; 8</b>
+  /// ```
+  ///
+  /// This may result in parsing errors if the input contains escaped angled
+  /// brackets (`&lt;`, `&gt;`). In such cases, automatic unescaping may be
+  /// disabled via the [unescapeContent] flag.
 
   static TextSpan toTextSpan(BuildContext context, String htmlContent, {
     Function(dynamic)? linksCallback,
@@ -126,6 +136,16 @@ class HTML {
   ///   },
   /// );
   /// ```
+  ///
+  /// HTML content is unescaped by default before parsing to render escape
+  /// entities contained in the input. For example:
+  /// ```
+  /// <b>2 &times; 4 &#61; 8</b>
+  /// ```
+  ///
+  /// This may result in parsing errors if the input contains escaped angled
+  /// brackets (`&lt;`, `&gt;`). In such cases, automatic unescaping may be
+  /// disabled via the [unescapeContent] flag.
 
   static RichText toRichText(BuildContext context, String htmlContent, {
     Function(dynamic)? linksCallback,

--- a/lib/src/html_stylist.dart
+++ b/lib/src/html_stylist.dart
@@ -59,7 +59,8 @@ class HTML {
   static TextSpan toTextSpan(BuildContext context, String htmlContent,
       {Function(dynamic)? linksCallback,
       Map<String, TextStyle>? overrideStyle,
-      TextStyle? defaultTextStyle}) {
+      TextStyle? defaultTextStyle,
+      bool unescapeContent = true}) {
     // Validating empty content
     if (htmlContent.isEmpty) {
       return const TextSpan();
@@ -73,7 +74,11 @@ class HTML {
     // to fix a known issue with non self closing <br> tags
     content = content.replaceAll('<br>', '<br />');
 
-    final Parser parser = Parser(context, HtmlUnescape().convert(content),
+    if (unescapeContent) {
+      content = HtmlUnescape().convert(content);
+    }
+
+    final Parser parser = Parser(context, content,
         linksCallback: linksCallback,
         overrideStyleMap: overrideStyle ?? <String, TextStyle>{},
         defaultTextStyle: defaultTextStyle);
@@ -124,7 +129,8 @@ class HTML {
   static RichText toRichText(BuildContext context, String htmlContent,
       {Function(dynamic)? linksCallback,
       Map<String, TextStyle>? overrideStyle,
-      TextStyle? defaultTextStyle}) {
+      TextStyle? defaultTextStyle,
+      bool unescapeContent = true}) {
     return RichText(
       text: toTextSpan(
         context,
@@ -132,6 +138,7 @@ class HTML {
         linksCallback: linksCallback,
         overrideStyle: overrideStyle,
         defaultTextStyle: defaultTextStyle,
+        unescapeContent: unescapeContent,
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: simple_html_css
 description: This package allows you to use simple HTML and inline CSS styles to style your text in flutter. A fork of css_text package.
-version: 4.0.0
+version: 4.0.1
 homepage: https://github.com/ali-thowfeek/simple_html_css_flutter
 repository: https://github.com/ali-thowfeek/simple_html_css_flutter
 


### PR DESCRIPTION
As suggested in https://github.com/ali-thowfeek/simple_html_css_flutter/issues/17#issuecomment-1772417562, this PR:

* Adds a `unescapeContent` boolean flag to both `toTextSpan` and `toRichText`.
* Default value is set to `true` for backward compatibility.