### PR TITLE
Add visual feedback when link is tapped

### DIFF
--- a/lib/src/internals.dart
+++ b/lib/src/internals.dart
@@ -114,16 +114,25 @@ class Parser {
 
     if (isLink) {
       return TextSpan(
-        style: textStyle,
-        text: text,
-        recognizer: TapGestureRecognizer()
-          ..onTap = () {
-            if (linksCallback != null) {
-              linksCallback!(link);
-            } else {
-              debugPrint('Add a link callback to visit ${link.toString()}');
-            }
-          },
+        children: [
+          WidgetSpan(
+            alignment: PlaceholderAlignment.baseline,
+            baseline: TextBaseline.alphabetic,
+            child: Material(
+              type: MaterialType.transparency,
+              child: InkWell(
+                onTap: () {
+                  if (linksCallback != null) {
+                    linksCallback!(link);
+                  } else {
+                    debugPrint('Add a link callback to visit ${link.toString()}');
+                  }
+                },
+                child: Text(text, style: textStyle),
+              ),
+            ),
+          ),
+        ],
       );
     }
     return TextSpan(style: textStyle, text: text);
@@ -329,7 +338,10 @@ class Parser {
 
       if (event is XmlTextEvent) {
         final TextSpan currentSpan = _handleText(event.value);
-        if (currentSpan.text?.isNotEmpty == true) {
+        if (
+          currentSpan.text?.isNotEmpty == true || 
+          currentSpan.children?.isNotEmpty == true
+        ) {
           spans.add(currentSpan);
         }
       }

--- a/lib/src/internals.dart
+++ b/lib/src/internals.dart
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:xml/xml_events.dart';
 


### PR DESCRIPTION
- Using InkWell for feedback
- Wrapped in a Material widget so "splash" will always be visible
- WidgetSpan wrapped by TextSpan as that is what `_getTextSpan` needs to return
- Added logic for `parse` to also display a span if it has children (but no text)

https://github.com/user-attachments/assets/c4d5bbec-3d08-44d3-924e-52f12306ea3f
